### PR TITLE
Improve README setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,8 @@
-```
-gulp watch
-```
-
-
-
-## My Personal Website & Portfolio
-
-
+# My Personal Website & Portfolio
 
 This is my personal website and portfolio, designed and developed entirely by me, with a focus on minimal libraries and modern JavaScript techniques. Explore my work, projects, and passions, including full-stack development, UI/UX, and beatboxing.
 
-### Connect with Me:
+## Connect with Me
 - **GitHub**: [@enkr1](https://github.com/enkr1)
 - **Instagram**: [@enkr1](https://www.instagram.com/enkr1)
 
@@ -18,114 +10,51 @@ This is my personal website and portfolio, designed and developed entirely by me
 
 ---
 
-### Setup Guide:
+## Setup
 
-### Step 1: Install Node.js and Gulp CLI
-
-> Make sure sass version is at `npm install sass@1.79`
-
-#### 1. Install Node.js:
-- If you don’t have Node.js installed, download and install it from [Node.js official site](https://nodejs.org/).
-- Verify Node.js is installed by running:
-   ```bash
-   node -v
-   ```
-
-#### 2. Initialize the Project:
-- If this is a fresh setup, initialise the project:
-   ```bash
-   npm init -y
-   ```
-
-#### 3. Install Gulp CLI Globally:
-   ```bash
-   npm install -g gulp-cli
-   ```
-   Verify Gulp CLI installation:
-   ```bash
-   gulp -v
-   ```
-
-#### 4. Install Gulp Locally (and other dependencies):
-   ```bash
-   npm install gulp gulp-sass gulp-postcss autoprefixer --save-dev
-   ```
-
----
-
-### Step 2: Start Gulp Watcher
-
-Start the Gulp watcher to compile SCSS and add vendor prefixes automatically:
-
-```bash
-gulp watch
-```
-
----
-
-### Key Files:
-
-- **gulpfile.js**: The configuration file for Gulp, handling SCSS compilation and autoprefixing.
-  - Path: `./gulpfile.js`
-
-- **SCSS Source Folder**: Where the source SCSS files are located.
-  - Path: `./scss/`
-
-- **CSS Output Folder**: Where the compiled CSS files will be output.
-  - Path: `./css/`
-
----
-
-### Common Commands
-
-**Clear npm cache** (Useful for cleanup and troubleshooting):
-```bash
-npm cache clean --force
-```
-
-**Install Dependencies** (if starting on a new machine or after cleanup):
+Run the following commands to install dependencies and start the development watcher:
 ```bash
 npm install
-```
-
-**Start Gulp Watcher**:
-```bash
 gulp watch
-gulp watch &
 ```
 
-kill port
-```sh
-ps aux | grep gulp
+If you need to install the Gulp CLI globally:
+```bash
+npm install -g gulp-cli
 ```
-
-```sh
-kill -9 <PID>
-```
+Make sure your local `sass` version is `1.79`.
 
 ---
 
-### Obfuscator
-
-```sh
-node scripts/o.js
-```
-
+## Key Files
+- **gulpfile.js** – configuration for SCSS compilation and JS bundling
+- **SCSS Source Folder** – `./scss/`
+- **CSS Output Folder** – `./css/`
 
 ---
 
-### Future Development
+## Common Commands
+- **Clear npm cache**
+  ```bash
+  npm cache clean --force
+  ```
+- **Obfuscate bundled JS**
+  ```bash
+  node scripts/o.js
+  ```
 
-- This project is constantly evolving as I continue experimenting with modern, minimal JavaScript to create an engaging and interactive user experience.
+---
 
+## Future Development
+This project is constantly evolving as I continue experimenting with modern, minimal JavaScript to create an engaging and interactive user experience.
 
 ### TODO
-- [ ] Rework the design!
-- [ ] Lazy-load images and any non-essential assets to improve performance.
-- [ ] Defer and optimize the execution of JavaScript where possible, as you're already doing with the defer attribute.
-- [ ] Replace jQuery with vanilla JavaScript. This will reduce dependency and streamline performance.
-- [ ] Consider whether Swiper and AOS are necessary. If not, we could build custom solutions for carousels and scroll animations with vanilla JS and CSS.
-- [ ] Add dynamic animations or interactivity to elements like the landing section using CSS animations or JavaScript, ensuring responsiveness.
-- [ ] Incorporate progressive web app (PWA) features like offline mode, caching, and push notifications (optional).
-- [ ] Rework the eye-candy-component and the preloader using pure CSS or JavaScript to make the experience smoother and lighter.
-- [ ] Could refine these based on the latest SEO best practices to ensure maximum visibility.
+- [ ] Rework the design
+- [ ] Lazy-load images and any non-essential assets to improve performance
+- [ ] Defer and optimize JavaScript execution where possible
+- [ ] Replace jQuery with vanilla JavaScript
+- [ ] Consider replacing Swiper and AOS with custom solutions
+- [ ] Add dynamic animations or interactivity to the landing section
+- [ ] Incorporate progressive web app (PWA) features (optional)
+- [ ] Rework eye-candy-component and preloader with pure CSS or JavaScript
+- [ ] Refine SEO based on latest best practices


### PR DESCRIPTION
## Summary
- tidy up README
- add quick setup section showing how to run `gulp watch`

## Testing
- `npm test` *(fails: Missing script)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6872e45c96d4832f95b750caa1f57c07